### PR TITLE
Feature scoreboard admins

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -559,6 +559,16 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 				TextRender()->SetCursor(&Cursor, Cursor.m_X, y+Spacing, FontSize, TEXTFLAG_RENDER);
 				TextRender()->TextEx(&Cursor, "\xE2\x9C\x93", str_length("\xE2\x9C\x93"));
 			}
+
+			// admin detection
+			if(g_Config.m_ClShowAdmins && (pInfo->m_pPlayerInfo->m_PlayerFlags&PLAYERFLAG_ADMIN))
+			{
+				if(HighlightedLine)
+					TextRender()->TextOutlineColor(0.1f, 0.0f, 0.0f, 0.5f);
+				TextRender()->TextColor(1.0f, 0.1f, 0.1f, ColorAlpha);
+				TextRender()->SetCursor(&Cursor, Cursor.m_X+1, y+Spacing, FontSize, TEXTFLAG_RENDER);
+				TextRender()->TextEx(&Cursor, "*", str_length("*"));
+			}
 			TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, ColorAlpha);
 			TextRender()->TextOutlineColor(OutlineColor.r, OutlineColor.g, OutlineColor.b, OutlineColor.a);
 

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -546,6 +546,13 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 				RenderTools()->DrawClientID(TextRender(), &Cursor, pInfo->m_ClientID);
 			}
 
+			// admin detection
+			if(g_Config.m_ClShowAdmins && (pInfo->m_pPlayerInfo->m_PlayerFlags&PLAYERFLAG_ADMIN))
+			{
+				if(HighlightedLine)
+					TextRender()->TextOutlineColor(0.0f, 0.1f, 0.0f, 0.5f);
+				TextRender()->TextColor(0.1f, 1.0f, 0.1f, ColorAlpha);
+			}
 			// name
 			TextRender()->SetCursor(&Cursor, NameOffset+TeeLength, y+Spacing, FontSize, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
 			Cursor.m_LineWidth = NameLength-TeeLength;
@@ -558,16 +565,6 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 				TextRender()->TextColor(0.1f, 1.0f, 0.1f, ColorAlpha);
 				TextRender()->SetCursor(&Cursor, Cursor.m_X, y+Spacing, FontSize, TEXTFLAG_RENDER);
 				TextRender()->TextEx(&Cursor, "\xE2\x9C\x93", str_length("\xE2\x9C\x93"));
-			}
-
-			// admin detection
-			if(g_Config.m_ClShowAdmins && (pInfo->m_pPlayerInfo->m_PlayerFlags&PLAYERFLAG_ADMIN))
-			{
-				if(HighlightedLine)
-					TextRender()->TextOutlineColor(0.1f, 0.0f, 0.0f, 0.5f);
-				TextRender()->TextColor(1.0f, 0.1f, 0.1f, ColorAlpha);
-				TextRender()->SetCursor(&Cursor, Cursor.m_X+1, y+Spacing, FontSize, TEXTFLAG_RENDER);
-				TextRender()->TextEx(&Cursor, "*", str_length("*"));
 			}
 			TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, ColorAlpha);
 			TextRender()->TextOutlineColor(OutlineColor.r, OutlineColor.g, OutlineColor.b, OutlineColor.a);

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -139,11 +139,13 @@ MACRO_CONFIG_INT(SvVoteKickBantime, sv_vote_kick_bantime, 5, 0, 1440, CFGFLAG_SA
 MACRO_CONFIG_INT(DbgFocus, dbg_focus, 0, 0, 1, CFGFLAG_CLIENT, "")
 MACRO_CONFIG_INT(DbgTuning, dbg_tuning, 0, 0, 1, CFGFLAG_CLIENT, "")
 
-// DDRace
+// ZillyWoods
 
 MACRO_CONFIG_INT(ClDefaultZoom, cl_default_zoom, 10, 0, 20, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Default zoom level (10 default, min 0, max 20)")
 MACRO_CONFIG_STR(ClTimeoutCode, cl_timeout_code, 64, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Timeout code to use")
 MACRO_CONFIG_INT(ClTextEntities, cl_text_entities, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Render textual entity data")
 MACRO_CONFIG_INT(ClTextEntitiesSize, cl_text_entities_size, 100, 0, 100, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Size of textual entity data from 0 to 100%")
+
+MACRO_CONFIG_INT(ClShowAdmins, cl_show_admins, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Display admins in the scoreboard")
 
 #endif


### PR DESCRIPTION
![Teeworlds_admin_scoreboard](https://user-images.githubusercontent.com/20344300/65629824-69a51c80-dfd4-11e9-842f-3a17c8469d9b.png)
Highlight admin names green in scoreboard.

Thanks to @LordSk for:
https://github.com/teeworlds/teeworlds/commit/a50b99bf4fd28a280956f8b9b7c7a91cf4b08bdd#diff-c8e2ff2cbdf8bc77290ae2602176a220

And @Dune-jr for:
https://github.com/Dune-jr/teeworlds/commit/467fdba231f8f45cbeca87db55d0e72f5af310dc